### PR TITLE
Add a .validate() function to SchemaModel

### DIFF
--- a/app/ashlar/__init__.py
+++ b/app/ashlar/__init__.py
@@ -15,7 +15,7 @@ app.config.from_object('config')
 # Define the database object which is imported
 # by modules and controllers
 # TODO: set up database
-# db = SQLAlchemy(app)
+db = SQLAlchemy(app)
 
 # Sample HTTP error handling
 @app.errorhandler(404)

--- a/app/ashlar/ashlar/models.py
+++ b/app/ashlar/ashlar/models.py
@@ -9,8 +9,9 @@ import jsonschema
 
 from geoalchemy2.types import Geometry
 
+from ashlar import db
 
-BaseModel = declarative_base()
+BaseModel = db.Model
 
 
 class AshlarModel(BaseModel):
@@ -26,6 +27,15 @@ class SchemaModel(AshlarModel):
 
     version = Column(Integer, nullable=False)
     schema = Column(JSONB)
+
+    def validate_json(self, json_dict):
+        """Validates a JSON-like dictionary against this object's schema
+
+        :param json_dict: Python dict representing json to be validated against self.schema
+        :return: None if validation succeeds; jsonschema.exceptions.ValidationError if failure
+                 (or jsonschema.exceptions.SchemaError if the schema is invalid)
+        """
+        return jsonschema.validate(json_dict, self.schema)
 
 
 class Record(AshlarModel):

--- a/app/ashlar/ashlar/models.py
+++ b/app/ashlar/ashlar/models.py
@@ -4,6 +4,7 @@ from sqlalchemy.types import Integer, String, Float, DateTime
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy import func, UniqueConstraint
 from sqlalchemy.schema import Index
+from sqlalchemy.orm import validates
 
 import jsonschema
 
@@ -36,6 +37,17 @@ class SchemaModel(AshlarModel):
                  (or jsonschema.exceptions.SchemaError if the schema is invalid)
         """
         return jsonschema.validate(json_dict, self.schema)
+
+    @validates('schema')
+    def validate_schema(self, key, schema):
+        """Validates that this object's schema is a valid JSON-Schema schema
+        :param key: Name of the field being validated
+        :param schema: Python dict representing json schema that should be checked
+        :return: None if schema validates; raises jsonschema.exceptions.SchemaError
+            if schema is invalid
+        """
+        jsonschema.Draft4Validator.check_schema(schema)
+        return schema
 
 
 class Record(AshlarModel):

--- a/app/shell.py
+++ b/app/shell.py
@@ -5,5 +5,6 @@ from pprint import pprint
 
 from flask import *
 from ashlar import *
+from ashlar.ashlar.models import *
 
 os.environ['PYTHONINSPECT'] = 'True'


### PR DESCRIPTION
Still needs tests. Basically just a thin wrapper around `jsonschema.validate()`

Example:

```
In [1]: schema = RecordSchema.query.filter_by(record_type="testType", version=1).first()

In [2]: schema.schema
Out[2]: 
{u'properties': {u'name': {u'type': u'string'},
  u'price': {u'type': u'number'}},
 u'type': u'object'}

In [3]: schema.validate_json({"name" : "Eggs", "price" : 34.99})

In [4]: schema.validate_json({"name" : "Eggs", "price" : "Invalid"})
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-4-68367df870a7> in <module>()
----> 1 schema.validate_json({"name" : "Eggs", "price" : "Invalid"})

/opt/app/ashlar/ashlar/models.pyc in validate_json(self, json_dict)
     36                  (or jsonschema.exceptions.SchemaError if the schema is invalid)
     37         """
---> 38         return jsonschema.validate(json_dict, self.schema)
     39 
     40 

/usr/local/lib/python2.7/dist-packages/jsonschema/validators.pyc in validate(instance, schema, cls, *args, **kwargs)
    426         cls = validator_for(schema)
    427     cls.check_schema(schema)
--> 428     cls(schema, *args, **kwargs).validate(instance)

/usr/local/lib/python2.7/dist-packages/jsonschema/validators.pyc in validate(self, *args, **kwargs)
    115         def validate(self, *args, **kwargs):
    116             for error in self.iter_errors(*args, **kwargs):
--> 117                 raise error
    118 
    119         def is_type(self, instance, type):

ValidationError: 'Invalid' is not of type u'number'

Failed validating u'type' in schema[u'properties'][u'price']:
    {u'type': u'number'}

On instance[u'price']:
    'Invalid'
```
