### PR TITLE
Add GIN index to JSONB fields via migration

### DIFF
--- a/app/ashlar/migrations/0002_auto_20150421_1724.py
+++ b/app/ashlar/migrations/0002_auto_20150421_1724.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from ashlar.models import RecordSchema, Record, ItemSchema
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ashlar', '0001_initial'),
+    ]
+
+    create_gin_index_sql = 'CREATE INDEX {index_name} ON {table} USING gin({column})'
+    drop_gin_index_sql = 'DROP INDEX IF EXISTS {index_name}'
+
+    def _get_field_db_column(cls, fieldname):
+        """Returns the name of the database column corresponding to a field on a Django Model
+
+        :param cls: Subjclass of django.db.models.Model
+        :param fieldname: Name of a field on cls
+        :returns: String with database column name corresponding to fieldname
+        """
+        # Both of these get_* functions return tuples of information; the
+        # numbers are just the indexes of the information we want, which is a
+        # Field instance and the db column name, respectively.
+        return cls._meta.get_field_by_name(fieldname)[0].get_attname_column()[1]
+
+    operations = [
+        # Records
+        migrations.RunSQL(create_gin_index_sql.format(index_name='ashlar_record_data_gin',
+                                                      table=Record._meta.db_table,
+                                                      column=_get_field_db_column(Record, 'data')),
+                          drop_gin_index_sql.format(index_name='ashlar_record_data_gin')),
+        # RecordSchema
+        migrations.RunSQL(create_gin_index_sql.format(index_name='ashlar_recordschema_schema_gin',
+                                                      table=RecordSchema._meta.db_table,
+                                                      column=_get_field_db_column(RecordSchema, 'schema')),
+                          drop_gin_index_sql.format(index_name='ashlar_recordschema_schema_gin')),
+
+        # ItemSchema
+        migrations.RunSQL(create_gin_index_sql.format(index_name='ashlar_itemschema_schema_gin',
+                                                      table=ItemSchema._meta.db_table,
+                                                      column=_get_field_db_column(ItemSchema, 'schema')),
+                          drop_gin_index_sql.format(index_name='ashlar_itemschema_schema_gin'))
+    ]


### PR DESCRIPTION
Auto-discovers the database column being used for a field. Could be expanded to auto-discover all instances of JsonBFields being used in the app, but that wouldn't necessarily be what you want to do in all cases (c.f. space / time tradeoffs between GIST / GIN indexes).
