### PR TITLE
Fix nginx staticfiles

### DIFF
--- a/deployment/ansible/roles/ashlar.app/defaults/main.yml
+++ b/deployment/ansible/roles/ashlar.app/defaults/main.yml
@@ -5,8 +5,8 @@ app_log: "/var/log/ashlar.log"
 root_app_dir: "/opt/app"
 ashlar_session_timeout_s: 40
 root_py_dir: "{{ root_app_dir }}/ashlar"
-root_static_dir: "/var/www/static"
+root_www_dir: "/var/www"
+root_static_dir: "{{ root_www_dir }}/static"
 
 database_driver: "postgresql"
 database_host: "database.service.ashlar.internal"
-database_uri: "{{ database_driver }}://{{ postgresql_username }}:{{ postgresql_password }}@{{ database_host }}/{{ postgresql_database }}"

--- a/deployment/ansible/roles/ashlar.app/templates/nginx-default.j2
+++ b/deployment/ansible/roles/ashlar.app/templates/nginx-default.j2
@@ -13,6 +13,6 @@ server {
     }
 
     location /static/ {
-        alias {{ root_static_dir }}/;
+        root {{ root_www_dir }}/;
     }
 }


### PR DESCRIPTION
Fixes the nginx static files path; according to the Nginx docs it is "better" to use the `root` directive in this case. http://nginx.org/en/docs/http/ngx_http_core_module.html#alias
