### PR TITLE
Schema API versioning

### DIFF
--- a/app/ashlar/migrations/0007_auto_20150427_2114.py
+++ b/app/ashlar/migrations/0007_auto_20150427_2114.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ashlar', '0006_auto_20150424_1857'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='itemschema',
+            name='next_version',
+            field=models.OneToOneField(related_name='previous_version', null=True, to='ashlar.ItemSchema'),
+        ),
+        migrations.AddField(
+            model_name='recordschema',
+            name='next_version',
+            field=models.OneToOneField(related_name='previous_version', null=True, to='ashlar.RecordSchema'),
+        ),
+    ]

--- a/app/ashlar/migrations/0008_auto_20150429_1313.py
+++ b/app/ashlar/migrations/0008_auto_20150429_1313.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ashlar', '0007_auto_20150427_2114'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='itemschema',
+            name='version',
+            field=models.PositiveIntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='recordschema',
+            name='version',
+            field=models.PositiveIntegerField(),
+        ),
+    ]

--- a/app/ashlar/migrations/0009_auto_20150429_1627.py
+++ b/app/ashlar/migrations/0009_auto_20150429_1627.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ashlar', '0008_auto_20150429_1313'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='itemschema',
+            name='next_version',
+            field=models.OneToOneField(related_name='previous_version', null=True, editable=False, to='ashlar.ItemSchema'),
+        ),
+        migrations.AlterField(
+            model_name='recordschema',
+            name='next_version',
+            field=models.OneToOneField(related_name='previous_version', null=True, editable=False, to='ashlar.RecordSchema'),
+        ),
+    ]

--- a/app/ashlar/models.py
+++ b/app/ashlar/models.py
@@ -11,8 +11,8 @@ import jsonschema
 from django.conf import settings
 
 from ashlar.imports.shapefile import (extract_zip_to_temp_dir,
-                                   get_shapefiles_in_dir,
-                                   make_multipolygon)
+                                      get_shapefiles_in_dir,
+                                      make_multipolygon)
 
 
 class AshlarModel(models.Model):
@@ -25,8 +25,9 @@ class AshlarModel(models.Model):
 
 
 class SchemaModel(AshlarModel):
-    version = models.IntegerField()
+    version = models.PositiveIntegerField()
     schema = JsonBField()
+    next_version = models.OneToOneField('self', related_name='previous_version', null=True, editable=False)
 
     class Meta(object):
         abstract = True
@@ -40,10 +41,9 @@ class SchemaModel(AshlarModel):
         """
         return jsonschema.validate(json_dict, self.schema)
 
-    # TODO: May want to move to serializer
-    def validate_schema(self, key, schema):
+    @classmethod
+    def validate_schema(self, schema):
         """Validates that this object's schema is a valid JSON-Schema schema
-        :param key: Name of the field being validated
         :param schema: Python dict representing json schema that should be checked
         :return: None if schema validates; raises jsonschema.exceptions.SchemaError
             if schema is invalid

--- a/app/ashlar/models.py
+++ b/app/ashlar/models.py
@@ -27,7 +27,8 @@ class AshlarModel(models.Model):
 class SchemaModel(AshlarModel):
     version = models.PositiveIntegerField()
     schema = JsonBField()
-    next_version = models.OneToOneField('self', related_name='previous_version', null=True, editable=False)
+    next_version = models.OneToOneField('self', related_name='previous_version', null=True,
+                                        editable=False)
 
     class Meta(object):
         abstract = True
@@ -67,12 +68,17 @@ class Record(AshlarModel):
 
 class RecordSchema(SchemaModel):
     """Schemas for spatiotemporal records"""
+    # TODO: This field may need to be broken out into a separate model so that it can
+    # supported label, slug_label, description, etc.
     record_type = models.CharField(max_length=50)
 
     class Meta(object):
         unique_together = (('record_type', 'version'),)
 
 
+# TODO: This model is currently not very useful and doesn't parallel the way
+# RecordSchemas work. This should be expanded or deleted as we get a better
+# sense of whether / how we want to use subschemas.
 class ItemSchema(SchemaModel):
     """Subschemas for logical "items" which can be included in Record data"""
     label = models.CharField(max_length=50)

--- a/app/ashlar/serializer_fields.py
+++ b/app/ashlar/serializer_fields.py
@@ -2,8 +2,10 @@ from django.core.exceptions import ValidationError
 
 from rest_framework.fields import Field
 
-import jsonschema
 from jsonschema.exceptions import SchemaError
+
+from ashlar.models import SchemaModel
+
 
 class JsonBField(Field):
     """ Custom serializer class for JsonB
@@ -34,7 +36,7 @@ class JsonSchemaField(JsonBField):
     def to_internal_value(self, value):
         super(JsonSchemaField, self).to_internal_value(value)
         try:
-            jsonschema.Draft4Validator.check_schema(value)
+            SchemaModel.validate_schema(value)
             return value
         except SchemaError as e:
             raise ValidationError('Invalid schema: {}'.format(e.message))

--- a/app/ashlar/serializer_fields.py
+++ b/app/ashlar/serializer_fields.py
@@ -2,9 +2,7 @@ from django.core.exceptions import ValidationError
 
 from rest_framework.fields import Field
 
-from jsonschema.exceptions import SchemaError
-
-from ashlar.models import SchemaModel
+from ashlar.validators import validate_json_schema
 
 
 class JsonBField(Field):
@@ -29,14 +27,6 @@ class JsonBField(Field):
 
 
 class JsonSchemaField(JsonBField):
-    """ Extend JsonBField to validate on conversion """
-
+    """Json Field that also validates whether it is a JSON-Schema"""
     type_name = 'JsonSchemaField'
-
-    def to_internal_value(self, value):
-        super(JsonSchemaField, self).to_internal_value(value)
-        try:
-            SchemaModel.validate_schema(value)
-            return value
-        except SchemaError as e:
-            raise ValidationError('Invalid schema: {}'.format(e.message))
+    validators = [validate_json_schema]

--- a/app/ashlar/tests/test_item_schema.py
+++ b/app/ashlar/tests/test_item_schema.py
@@ -1,0 +1,20 @@
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from ashlar.models import ItemSchema
+
+
+class ItemSchemaTestCase(TestCase):
+
+    def test_no_duplicate_slugs(self):
+        """Ensure that duplicate versions of the same schema cannot exist"""
+        ItemSchema.objects.create(schema={}, slug='item', version=1)
+        with transaction.atomic():  # The IntegrityError will prevent further queries otherwise
+            with self.assertRaises(IntegrityError):
+                ItemSchema.objects.create(schema={}, slug='item', version=1)
+
+        with transaction.atomic():  # The IntegrityError will prevent further queries otherwise
+            with self.assertRaises(IntegrityError):
+                ItemSchema.objects.create(schema={}, slug='item', version=2)
+
+        ItemSchema.objects.create(schema={}, slug='different_item', version=1)  # Should succeed

--- a/app/ashlar/tests/test_record_schema.py
+++ b/app/ashlar/tests/test_record_schema.py
@@ -1,0 +1,16 @@
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from ashlar.models import RecordSchema
+
+
+class RecordSchemaTestCase(TestCase):
+
+    def test_no_duplicate_versions(self):
+        """Ensure that duplicate versions of the same schema cannot exist"""
+        RecordSchema.objects.create(schema={}, record_type='record', version=1)
+        with transaction.atomic():  # The IntegrityError will prevent further queries otherwise
+            with self.assertRaises(IntegrityError):
+                RecordSchema.objects.create(schema={}, record_type='record', version=1)
+
+        RecordSchema.objects.create(schema={}, record_type='record', version=2)  # Should succeed

--- a/app/ashlar/tests/test_schema_model.py
+++ b/app/ashlar/tests/test_schema_model.py
@@ -2,11 +2,16 @@ from django.test import TestCase
 
 import jsonschema
 
-from ashlar.models import SchemaModel
+from ashlar.models import RecordSchema, SchemaModel
 
 
 class SchemaModelTestCase(TestCase):
     """Test SchemaModel abstract class"""
+    def test_class_hierarchy(self):
+        """Make sure that RecordSchema is a subclass of SchemaModel"""
+        # Because we use it as a non-abstract stand-in for SchemaModel
+        # throughout these tests
+        self.assertTrue(issubclass(RecordSchema, SchemaModel))
 
     def test_validate_json(self):
         """Ensure that the validation function returns None / raises on invalid"""
@@ -19,9 +24,10 @@ class SchemaModelTestCase(TestCase):
         valid = {"name": "Eggs", "price": 34.99}
         invalid = {"name": "Eggs", "price": "Invalid"}
 
-        # SchemaModel is an "abstract" class in database terms but that doesn't
-        # prevent us from instantiating it without saving for testing purposes
-        test_model = SchemaModel(schema=test_schema)
+        # We have to use a RecordSchema here because SchemaModel itself is
+        # abstract and the ForeignKey to 'self' prevents it from being
+        # instantiated.
+        test_model = RecordSchema(schema=test_schema)
 
         self.assertIsNone(test_model.validate_json(valid))
 
@@ -32,7 +38,7 @@ class SchemaModelTestCase(TestCase):
         """Test that validating json will first validate the schema"""
         invalid_schema = {"type": "any"}
         valid_json = {}
-        test_model = SchemaModel(schema=invalid_schema)
+        test_model = RecordSchema(schema=invalid_schema)
 
         with self.assertRaises(jsonschema.exceptions.SchemaError):
             test_model.validate_json(valid_json)

--- a/app/ashlar/validators.py
+++ b/app/ashlar/validators.py
@@ -1,0 +1,12 @@
+from django.core.exceptions import ValidationError
+
+import jsonschema
+from jsonschema.exceptions import SchemaError
+
+
+def validate_json_schema(value):
+    """Wrap jsonschema validation with serializers.ValidationError"""
+    try:
+        jsonschema.Draft4Validator.check_schema(value)
+    except SchemaError as e:
+        raise ValidationError('Invalid schema: {}'.format(e.message))

--- a/app/ashlar/views.py
+++ b/app/ashlar/views.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from rest_framework import status, viewsets
+from rest_framework import viewsets, mixins
 from rest_framework.decorators import detail_route
 from rest_framework.filters import DjangoFilterBackend
 from rest_framework.response import Response
@@ -28,8 +28,15 @@ class RecordViewSet(viewsets.ModelViewSet):
     filter_backends = (InBBoxFilter, JsonBFilterBackend, DjangoFilterBackend)
 
 
-class RecordSchemaViewSet(viewsets.ModelViewSet):
+class SchemaViewSet(viewsets.GenericViewSet,
+                    mixins.ListModelMixin,
+                    mixins.CreateModelMixin,
+                    mixins.RetrieveModelMixin,
+                    mixins.UpdateModelMixin):  # No deletion
+    """Base ViewSet for viewsets displaying subclasses of SchemaModel"""
 
+
+class RecordSchemaViewSet(SchemaViewSet):
     queryset = RecordSchema.objects.all()
     serializer_class = RecordSchemaSerializer
     jsonb_filter_field = 'schema'
@@ -39,8 +46,7 @@ class RecordSchemaViewSet(viewsets.ModelViewSet):
     filter_backends = (JsonBFilterBackend, DjangoFilterBackend)
 
 
-class ItemSchemaViewSet(viewsets.ModelViewSet):
-
+class ItemSchemaViewSet(SchemaViewSet):
     queryset = ItemSchema.objects.all()
     serializer_class = ItemSchemaSerializer
     jsonb_filter_field = 'schema'


### PR DESCRIPTION
This sets up the RecordSchema viewset to generate versioned schemas. It also adds a "next_version" field to each RecordSchema which provides the next version of that schema, so that a set of versions is essentially a linked list.

This doesn't really deal much with ItemSchemas, except to keep their features roughly in line with RecordSchema. After discussing with @CloudNiner , we agreed that we're not totally clear on whether or how we'll be using ItemSchemas, so it seemed to make more sense to let them sit until we have a better idea of the use cases.

Another item that came up as a result of this is that it would probably be a good idea to represent Record Types as a separate model and reference them from RecordSchemas using a foreign key. This adds a to-do in the RecordSchema class.

@CloudNiner may want to take a look too.
