### PR TITLE
Add current_schema property to record_type GET

### DIFF
--- a/ashlar/serializers.py
+++ b/ashlar/serializers.py
@@ -20,8 +20,14 @@ class RecordSerializer(GeoModelSerializer):
 
 class RecordTypeSerializer(ModelSerializer):
 
+    current_schema = serializers.SerializerMethodField()
+
     class Meta:
         model = RecordType
+
+    def get_current_schema(self, obj):
+        current_schema = obj.get_current_schema()
+        return current_schema.schema if current_schema is not None else None
 
 
 class SchemaSerializer(ModelSerializer):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -87,6 +87,39 @@ class RecordSchemaViewTestCase(AshlarAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED, response.content)
 
 
+class RecordTypeViewTestCase(AshlarAPITestCase):
+
+    def setUp(self):
+        super(RecordTypeViewTestCase, self).setUp()
+
+        self.schema = {
+            "type": "object",
+            "properties": {}
+        }
+
+    def test_record_type_has_current_schema(self):
+        """ Test current schema exists and updates when we create a new schema """
+        record_type = RecordType.objects.create(label='foo', plural_label='foos')
+        record_schema = RecordSchema.objects.create(schema=self.schema,
+                                                    version=1,
+                                                    record_type=record_type)
+        url = reverse('recordtype-detail', args=(record_type.pk,))
+        response = self.client.get(url)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data['current_schema'], self.schema, response_data)
+
+        new_schema = dict(self.schema)
+        new_schema['title'] = 'New Schema'
+        record_schema = RecordSchema.objects.create(schema=new_schema,
+                                                    version=2,
+                                                    record_type=record_type)
+
+        url = reverse('recordtype-detail', args=(record_type.pk,))
+        response = self.client.get(url)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data['current_schema'], new_schema, response_data)
+
+
 class BoundaryViewTestCase(AshlarAPITestCase):
 
     def setUp(self):


### PR DESCRIPTION
Greatly simplifies displaying the list of related objects, since we get the current valid schema directly rather than having to query for it against `/api/recordschemas/` using a bunch of filters.
