### PR TITLE
Provide current schema as UUID so it can easily be looked up

### DIFF
--- a/ashlar/serializers.py
+++ b/ashlar/serializers.py
@@ -1,4 +1,5 @@
 from django.db import transaction
+from django.forms.models import model_to_dict
 
 from rest_framework import fields
 from rest_framework import serializers
@@ -27,7 +28,10 @@ class RecordTypeSerializer(ModelSerializer):
 
     def get_current_schema(self, obj):
         current_schema = obj.get_current_schema()
-        return current_schema.schema if current_schema is not None else None
+        uuid = None
+        if current_schema:
+            uuid = str(current_schema.uuid)
+        return uuid
 
 
 class SchemaSerializer(ModelSerializer):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -106,18 +106,18 @@ class RecordTypeViewTestCase(AshlarAPITestCase):
         url = reverse('recordtype-detail', args=(record_type.pk,))
         response = self.client.get(url)
         response_data = json.loads(response.content)
-        self.assertEqual(response_data['current_schema'], self.schema, response_data)
+        self.assertEqual(response_data['current_schema'], str(record_schema.uuid), response_data)
 
         new_schema = dict(self.schema)
         new_schema['title'] = 'New Schema'
-        record_schema = RecordSchema.objects.create(schema=new_schema,
-                                                    version=2,
-                                                    record_type=record_type)
+        new_record_schema = RecordSchema.objects.create(schema=new_schema,
+                                                        version=2,
+                                                        record_type=record_type)
 
         url = reverse('recordtype-detail', args=(record_type.pk,))
         response = self.client.get(url)
         response_data = json.loads(response.content)
-        self.assertEqual(response_data['current_schema'], new_schema, response_data)
+        self.assertEqual(response_data['current_schema'], str(new_record_schema.uuid), response_data)
 
 
 class BoundaryViewTestCase(AshlarAPITestCase):


### PR DESCRIPTION
Switch current_schema property to provide UUID to current_schema, more useful in the generic case.

Blocker for continuing progress, so going to merge and address any comments later.
