### PR TITLE
Boundary filtering support

### DIFF
--- a/ashlar/serializer_fields.py
+++ b/ashlar/serializer_fields.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.contrib.gis.geos import GEOSGeometry
 
 from rest_framework.fields import Field
 
@@ -30,3 +31,15 @@ class JsonSchemaField(JsonBField):
     """Json Field that also validates whether it is a JSON-Schema"""
     type_name = 'JsonSchemaField'
     validators = [validate_json_schema]
+
+
+class GeomBBoxField(Field):
+    """Serialize a geometry as a bounding box"""
+    read_only = True
+
+    def to_representation(self, value):
+        if not (issubclass(value.__class__, GEOSGeometry)):
+            msg = 'Can\'t apply GeomBBoxField to non-Geometry class {cls}'
+            raise ValidationError(msg.format(cls=value.__class__.__name__))
+        xmin, ymin, xmax, ymax = value.extent
+        return ({"lon": xmin, "lat": ymin}, {"lon": xmax, "lat": ymax})

--- a/ashlar/serializers.py
+++ b/ashlar/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework_gis.serializers import GeoFeatureModelSerializer, GeoModelSerializer
 
 from ashlar.models import Boundary, BoundaryPolygon, Record, RecordType, RecordSchema
-from ashlar.serializer_fields import JsonBField, JsonSchemaField
+from ashlar.serializer_fields import JsonBField, JsonSchemaField, GeomBBoxField
 
 
 class RecordSerializer(GeoModelSerializer):
@@ -70,6 +70,16 @@ class BoundaryPolygonSerializer(GeoFeatureModelSerializer):
         geo_field = 'geom'
         id_field = 'uuid'
         exclude = ('boundary',)
+
+
+class BoundaryPolygonNoGeomSerializer(ModelSerializer):
+    """Serialize a BoundaryPolygon without any geometry info"""
+    data = JsonBField()
+    bbox = GeomBBoxField(source='geom')
+
+    class Meta:
+        model = BoundaryPolygon
+        exclude = ('geom',)
 
 
 class BoundarySerializer(GeoModelSerializer):

--- a/ashlar/views.py
+++ b/ashlar/views.py
@@ -17,6 +17,7 @@ from ashlar.models import (Boundary,
                            RecordSchema)
 from ashlar.serializers import (BoundarySerializer,
                                 BoundaryPolygonSerializer,
+                                BoundaryPolygonNoGeomSerializer,
                                 RecordSerializer,
                                 RecordTypeSerializer,
                                 RecordSchemaSerializer)
@@ -39,6 +40,11 @@ class BoundaryPolygonViewSet(viewsets.ModelViewSet):
     bbox_filter_field = 'geom'
     jsonb_filter_field = 'data'
     filter_backends = (InBBoxFilter, JsonBFilterBackend, DjangoFilterBackend)
+
+    def get_serializer_class(self):
+        if 'nogeom' in self.request.query_params and self.request.query_params['nogeom']:
+            return BoundaryPolygonNoGeomSerializer
+        return BoundaryPolygonSerializer
 
 
 class RecordViewSet(viewsets.ModelViewSet):

--- a/tests/test_serializer_fields_bbox.py
+++ b/tests/test_serializer_fields_bbox.py
@@ -1,0 +1,21 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.contrib.gis.geos import Polygon, MultiPolygon
+
+from ashlar.serializer_fields import GeomBBoxField
+
+
+class GeomBBoxFieldTestCase(TestCase):
+    """ Test serializer field for JsonB """
+
+    def setUp(self):
+        self.bbox_field = GeomBBoxField()
+        self.poly = MultiPolygon(Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0))))
+
+    def test_to_representation(self):
+        rep = self.bbox_field.to_representation(self.poly)
+        self.assertEqual(({"lat": 0.0, "lon": 0.0}, {"lat": 1.0, "lon": 1.0}), rep)
+
+    def test_validation(self):
+        with self.assertRaises(ValidationError):
+            self.bbox_field.to_representation("not a geometry")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -8,7 +8,8 @@ from django.contrib.gis.geos import Polygon, LinearRing, MultiPolygon
 from rest_framework import status
 
 from tests.api_test_case import AshlarAPITestCase
-from ashlar.models import Boundary, RecordSchema, RecordType, Record
+from ashlar.models import (Boundary, BoundaryPolygon,
+                           RecordSchema, RecordType, Record)
 
 
 class RecordViewTestCase(AshlarAPITestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime, timedelta
 
 from django.core.urlresolvers import reverse
+from django.contrib.gis.geos import Polygon, LinearRing, MultiPolygon
 
 from rest_framework import status
 
@@ -282,3 +283,21 @@ class BoundaryViewTestCase(AshlarAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['type'], 'FeatureCollection')
         self.assertEqual(len(response.data['features']), 3)
+
+
+class BoundaryPolygonViewTestCase(AshlarAPITestCase):
+    def setUp(self):
+        boundary = Boundary.objects.create(label='fooOK', source_file='foo.zip',
+                                           status=Boundary.StatusTypes.COMPLETE)
+        coords = ((0, 0), (0, 1), (1, 1), (1, 0), (0, 0))
+        self.poly = BoundaryPolygon.objects.create(data={},
+                                                   geom=MultiPolygon(Polygon(LinearRing(coords))),
+                                                   boundary=boundary)
+
+    def test_no_geom_param(self):
+        """Make sure that the nogeom param excludes the geometry and includes a bounding box"""
+        super(BoundaryPolygonViewTestCase, self).setUp()
+        url = reverse('boundarypolygon-detail', args=[self.poly.uuid])
+        response = self.client.get(url, {'nogeom': True})
+        self.assertIn('bbox', response.data)
+        self.assertNotIn('geom', response.data)


### PR DESCRIPTION
Supporting PR for https://github.com/WorldBank-Transport/DRIVER/pull/201
- Adds a `nogeom` parameter to the `boundarypolygons` API view that causes it to return regular JSON with a bounding box, rather than GeoJSON. This provides a nice speed boost to page load times. Closes https://github.com/WorldBank-Transport/DRIVER/issues/146
- Adds a `polygon_id` parameter to the `/records` API view that can be used to filter records to those contained within the polygon with a matching UUID.
