### PR TITLE
Add MethodTransformJsonField

### DIFF
--- a/ashlar/serializer_fields.py
+++ b/ashlar/serializer_fields.py
@@ -27,6 +27,56 @@ class JsonBField(Field):
             raise ValidationError('Array or object required')
 
 
+class DropJsonKeyException(Exception):
+    """A way for JSON transformation functions to signal that a field should be dropped.
+
+    Raising this exception from a transform function does not imply an error condition, but rather
+    signals to the MethodTransformJsonField that the key/value pair passed to the transformation
+    function should be omitted from the response.
+    """
+    pass
+
+
+class MethodTransformJsonField(Field):
+    """Custom field to filter JSON fields by serializer method before returning
+
+    Must be supplied the name of a filter_method on initialization. The filter_method
+    must be a method on the parent serializer and will be passed two parameters:
+        - key (the key at the root level of the JSON object)
+        - val (the value associated with key)
+    filter_method should return a transformed version of value, or raise a DropJsonKeyException
+    to specify that the key/value pair should be dropped from the response.
+    """
+    # Loosely adapted from DRF's SerializerMethodField
+    type_name = 'MethodFilteredJsonField'
+
+    def __init__(self, transform_method_name=None, **kwargs):
+        self.transform_method_name = transform_method_name
+        kwargs['read_only'] = True
+        super(MethodTransformJsonField, self).__init__(**kwargs)
+
+    def bind(self, field_name, parent):
+        default_transform = 'transform_{field_name}'.format(field_name=field_name)
+        if self.transform_method_name is None:
+            self.transform_method_name = default_transform
+        super(MethodTransformJsonField, self).bind(field_name, parent)
+
+    def to_representation(self, value):
+        """Transforms value's root-level key/value pairs based on parent.transform_method_name
+
+        Assumes value is a dict.
+        """
+        transform_method = getattr(self.parent, self.transform_method_name)
+        representation = {}
+        for key, val in value.viewitems():
+            try:
+                (new_key, new_val) = transform_method(key, val)
+                representation[new_key] = new_val
+            except DropJsonKeyException:
+                continue
+        return representation
+
+
 class JsonSchemaField(JsonBField):
     """Json Field that also validates whether it is a JSON-Schema"""
     type_name = 'JsonSchemaField'

--- a/ashlar/serializers.py
+++ b/ashlar/serializers.py
@@ -1,13 +1,11 @@
 from django.db import transaction
 from django.conf import settings
-from django.forms.models import model_to_dict
 
 import datetime
 import json
 import pytz
 import requests
 
-from rest_framework import fields
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 from rest_framework_gis.serializers import GeoFeatureModelSerializer, GeoModelSerializer


### PR DESCRIPTION
Roughly similar to DRF's SerializerMethodField, this field passes JSON
through a transform function, which can delete keys or alter values,
before returning it.

Supporting PR for https://github.com/WorldBank-Transport/DRIVER/pull/345
