### PR TITLE
Allow filtering record types by label

### DIFF
--- a/ashlar/filters.py
+++ b/ashlar/filters.py
@@ -63,7 +63,7 @@ class RecordTypeFilter(django_filters.FilterSet):
 
     class Meta:
         model = RecordType
-        fields = ['active']
+        fields = ['active', 'label']
 
 
 class BoundaryFilter(GeoFilterSet):


### PR DESCRIPTION
So endpoint may be used to find the most recent schema for the primary record type without having to iterate through all the available record types, as is done [here](https://github.com/WorldBank-Transport/DRIVER/blob/7a1b661d64902194fef98d6194abba8a0655a221/web/app/scripts/state/recordstate-service.js#L80).
