### PR TITLE
Add recordtype by record, get djsonb fix

### DIFF
--- a/ashlar/filters.py
+++ b/ashlar/filters.py
@@ -61,9 +61,16 @@ class RecordFilter(GeoFilterSet):
 
 class RecordTypeFilter(django_filters.FilterSet):
 
+    record = django_filters.MethodFilter(name='record', action='type_for_record')
+
+    def type_for_record(self, queryset, record_id):
+        """ Filter down to only the record type that corresponds to the given record. """
+        record = Record.objects.get(pk=record_id)
+        return queryset.filter(pk=record.schema.record_type_id)
+
     class Meta:
         model = RecordType
-        fields = ['active', 'label']
+        fields = ['active', 'label', 'record']
 
 
 class BoundaryFilter(GeoFilterSet):

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ setup(
     keywords='gis jsonschema',
     packages=find_packages(exclude=['tests']),
     dependency_links=[
-        'https://github.com/azavea/djsonb/tarball/develop#egg=djsonb-0.1.6'
+        'https://github.com/azavea/djsonb/tarball/develop#egg=djsonb-0.1.7'
     ],
     install_requires=[
         'Django ==1.8.6',
         'djangorestframework >=3.1.1',
         'djangorestframework-gis >=0.8.1',
         'django-filter >=0.9.2',
-        'djsonb >=0.1.6',
+        'djsonb >=0.1.7',
         'jsonschema >=2.4.0',
         'psycopg2 >=2.6',
         'django-extensions >=1.6.1',


### PR DESCRIPTION
Adds a filter for RecordType to get the record type that corresponds to a given record, to enable things like record detail views to get the right type and schema given a record ID.

Also increments the djsonb version to get the fix in https://github.com/azavea/djsonb/pull/10.
