### PR TITLE
Missed changes cleanup

### DIFF
--- a/ashlar/filters.py
+++ b/ashlar/filters.py
@@ -65,8 +65,9 @@ class RecordTypeFilter(django_filters.FilterSet):
 
     def type_for_record(self, queryset, record_id):
         """ Filter down to only the record type that corresponds to the given record. """
-        record = Record.objects.get(pk=record_id)
-        return queryset.filter(pk=record.schema.record_type_id)
+        record_type_id = Record.objects.filter(pk=record_id).values_list(
+            'schema__record_type_id', flat=True).first()
+        return queryset.filter(pk=record_type_id)
 
     class Meta:
         model = RecordType

--- a/ashlar/views.py
+++ b/ashlar/views.py
@@ -63,35 +63,6 @@ class RecordTypeViewSet(viewsets.ModelViewSet):
     pagination_class = OptionalLimitOffsetPagination
     ordering = ('plural_label',)
 
-    @detail_route(methods=['get'])
-    def recent_counts(self, request, pk=None):
-        """ Return the recent record counts for a given a record type
-        where recent = 30, 90, 365 days
-        """
-        record_type = RecordType.objects.get(pk=pk)
-        now = datetime.now()
-        durations = {
-            'month': 30,
-            'quarter': 90,
-            'year': 365
-        }
-
-        counts = {
-            'month': 0,
-            'quarter': 0,
-            'year': 0
-        }
-
-        for schema in record_type.schemas.all():
-            for label, days in durations.items():
-                earliest = now - timedelta(days=days)
-                count = (schema.record_set
-                         .filter(occurred_from__lte=now, occurred_from__gte=earliest).count())
-                counts[label] += count
-
-        # Construct JSON representation of `counts` for the response
-        return Response(counts)
-
 
 class SchemaViewSet(viewsets.GenericViewSet,
                     mixins.ListModelMixin,


### PR DESCRIPTION
I just realized I missed a couple changes related to recent DRIVER commits.  I didn't notice because they're just cleanup, so DRIVER works fine either way.

0faec57 changes how the record-type-by-record-id filter does its query.

0ec47bd removes the recent_counts route from RecordTypeViewSet, because it was moved elsewhere in https://github.com/WorldBank-Transport/DRIVER/pull/455.
