### PR TITLE
Provide explicit version ranges for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
 
 addons:
   postgresql: "9.4"
+  apt:
+    packages:
+      - postgresql-9.4-postgis-2.3
 
 env:
   - DJANGO_SETTINGS_MODULE='settings_travis'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,10 @@ WORKDIR /opt/ashlar
 RUN apt-get update
 RUN apt-get -y autoremove && apt-get install -y libgeos-dev binutils libproj-dev gdal-bin
 
+# Dependency links were removed in pip>6. We should remove the external djsonb
+# dependency eventually, but for now just install an earlier version of pip that
+# can handle it.
+RUN pip install pip==6.0.7
+
 RUN pip install --process-dependency-links --allow-external djsonb -e .
 CMD python run_tests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ WORKDIR /opt/ashlar
 RUN apt-get update
 RUN apt-get -y autoremove && apt-get install -y libgeos-dev binutils libproj-dev gdal-bin
 
-# Dependency links were removed in pip>6. We should remove the external djsonb
-# dependency eventually, but for now just install an earlier version of pip that
-# can handle it.
-RUN pip install pip==6.0.7
+# --process-dependency-links is no longer a valid argument in pip 10. We should
+# remove the external djsonb dependency eventually, but for now just install
+# an earlier version of pip that can handle it.
+RUN pip install pip==9.0.1
 
 RUN pip install --process-dependency-links --allow-external djsonb -e .
 CMD python run_tests.py

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setup(
     ],
     install_requires=[
         'Django ==1.8.6',
-        'djangorestframework >=3.1.1',
-        'djangorestframework-gis >=0.8.1',
-        'django-filter >=0.9.2',
+        'djangorestframework >=3.1.1, <3.5.0',
+        'djangorestframework-gis >=0.8.1, <0.12.0',
+        'django-filter >=0.9.2, <0.14.0',
         'djsonb >=0.2.2',
         'jsonschema >=2.4.0',
         'psycopg2 >=2.6',


### PR DESCRIPTION
Since Travis last tested this project in [May of 2016](https://travis-ci.org/azavea/ashlar/builds/132585937), many of the dependencies required in `setup.py` have published new major versions with breaking changes. Travis has also undergone a major upgrade to Ubuntu 14.04, which has changed some configuration options.

This PR updates the project requirements to reflect the actual range of possible dependency versions for the app as it currently exists, and adjusts `.travis.yml` to get builds working again.